### PR TITLE
icmc.cls updated to support the new version of the listings package

### DIFF
--- a/packages/icmc.cls
+++ b/packages/icmc.cls
@@ -817,13 +817,13 @@
     \let\lst@PlaceNumber\@empty
     \lstKV@SwitchCases{#1}%
     {%
-      none&\\%
-      left&\def\lst@PlaceNumber{%
+      none:\\%
+      left:\def\lst@PlaceNumber{%
         \llap{%
           \normalfont\lst@numberstyle{\thelstnumber\lst@numbersymbol}\kern\lst@numbersep%
         }%
       }\\%
-        right&\def\lst@PlaceNumber{%
+        right:\def\lst@PlaceNumber{%
           \rlap{%
             \normalfont\kern\linewidth\kern\lst@numbersep\lst@numberstyle{\lst@numbersymbol\thelstnumber}%
           }%


### PR DESCRIPTION
Olá Humberto.

Em setembro do ano passado atualizaram o pacote "listings" do texlive e mudaram a sintaxe de um comando (https://tex.stackexchange.com/questions/451532/recent-issues-with-lstlinebgrd-package-with-listings-after-the-latters-updates). Isso impede que o projeto seja compilado com a versão atualizada do texlive 2018. Este pull request atualiza a sintaxe e resolve o problema. O problema é que versões do texlive anteriores à atualização de setembro não irão compilar o projeto e esse é o caso do Overleaf, que utiliza o texlive 2017 atualmente.

Fiz este pull request pois eventualmente alguém irá aparecer com este problema. Talvez seja melhor deixar ele de molho por enquanto.

Abraços e obrigado por manter o template :)
Brauner



