### PR TITLE
Add theorem labels for english language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,18 +2,29 @@
 *.aux
 *.lof
 *.log
+*.loq
+*.los
 *.lot
 *.fls
 *.out
 *.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
 
 ## Intermediate documents:
 *.dvi
+*.xdv
 *-converted-to.*
 # these rules might exclude image files for figures etc.
 # *.ps
 # *.eps
 # *.pdf
+
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
 
 ## Bibliography auxiliary files (bibtex/biblatex/biber):
 *.bbl
@@ -21,31 +32,65 @@
 *.blg
 *-blx.aux
 *-blx.bib
-*.brf
 *.run.xml
 
 ## Build tool auxiliary files:
 *.fdb_latexmk
+*.synctex
+*.synctex(busy)
 *.synctex.gz
 *.synctex.gz(busy)
 *.pdfsync
 
-## Auxiliary and intermediate files from other packages:
+## Build tool directories for auxiliary files
+# latexrun
+latex.out/
 
+## Auxiliary and intermediate files from other packages:
 # algorithms
 *.alg
 *.loa
+
+# achemso
+acs-*.bib
 
 # amsthm
 *.thm
 
 # beamer
 *.nav
+*.pre
 *.snm
 *.vrb
 
-#(e)ledmac/(e)ledpar
+# changes
+*.soc
+
+# comment
+*.cut
+
+# cprotect
+*.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
+
+# endnotes
+*.ent
+
+# fixme
+*.lox
+
+# feynmf/feynmp
+*.mf
+*.mp
+*.t[1-9]
+*.t[1-9][0-9]
+*.tfm
+
+#(r)(e)ledmac/(r)(e)ledpar
 *.end
+*.?end
 *.[1-9]
 *.[1-9][0-9]
 *.[1-9][0-9][0-9]
@@ -65,12 +110,37 @@
 *.glg
 *.glo
 *.gls
+*.glsdefs
+
+# gnuplottex
+*-gnuplottex-*
+
+# gregoriotex
+*.gaux
+*.gtex
+
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
 
 # hyperref
 *.brf
 
+# knitr
+*-concordance.tex
+# TODO Comment the next line if you want to keep your tikz graphics files
+*.tikz
+*-tikzDictionary
+
 # listings
 *.lol
+
+# luatexja-ruby
+*.ltjruby
 
 # makeidx
 *.idx
@@ -80,33 +150,115 @@
 
 # minitoc
 *.maf
-*.mtc
-*.mtc0
+*.mlf
+*.mlt
+*.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
 
 # minted
+_minted*
 *.pyg
 
 # morewrites
 *.mw
 
 # nomencl
+*.nlg
 *.nlo
+*.nls
+
+# pax
+*.pax
+
+# pdfpcnotes
+*.pdfpc
 
 # sagetex
 *.sagetex.sage
 *.sagetex.py
 *.sagetex.scmd
 
+# scrwfile
+*.wrt
+
 # sympy
 *.sout
 *.sympy
 sympy-plots-for-*.tex/
 
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# tcolorbox
+*.listing
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
 # todonotes
 *.tdo
+
+# vhistory
+*.hst
+*.ver
+
+# easy-todo
+*.lod
+
+# xcolor
+*.xcp
+
+# xmpincl
+*.xmpi
 
 # xindy
 *.xdy
 
-# MAC files
-.DS_Store
+# xypic precompiled matrices
+*.xyc
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# LyX
+*.lyx~
+
+# Kile
+*.backup
+
+# KBibTeX
+*~[0-9]*
+
+# auto folder when using emacs and auctex
+./auto/*
+*.el
+
+# expex forward references with \gathertags
+*-tags.tex
+
+# standalone packages
+*.sta

--- a/.gitignore
+++ b/.gitignore
@@ -16,15 +16,11 @@
 
 ## Intermediate documents:
 *.dvi
-*.xdv
 *-converted-to.*
 # these rules might exclude image files for figures etc.
 # *.ps
 # *.eps
 # *.pdf
-
-## Generated if empty string is given at "Please type another file name for output:"
-.pdf
 
 ## Bibliography auxiliary files (bibtex/biblatex/biber):
 *.bbl
@@ -32,65 +28,31 @@
 *.blg
 *-blx.aux
 *-blx.bib
+*.brf
 *.run.xml
 
 ## Build tool auxiliary files:
 *.fdb_latexmk
-*.synctex
-*.synctex(busy)
 *.synctex.gz
 *.synctex.gz(busy)
 *.pdfsync
 
-## Build tool directories for auxiliary files
-# latexrun
-latex.out/
-
 ## Auxiliary and intermediate files from other packages:
+
 # algorithms
 *.alg
 *.loa
-
-# achemso
-acs-*.bib
 
 # amsthm
 *.thm
 
 # beamer
 *.nav
-*.pre
 *.snm
 *.vrb
 
-# changes
-*.soc
-
-# comment
-*.cut
-
-# cprotect
-*.cpt
-
-# elsarticle (documentclass of Elsevier journals)
-*.spl
-
-# endnotes
-*.ent
-
-# fixme
-*.lox
-
-# feynmf/feynmp
-*.mf
-*.mp
-*.t[1-9]
-*.t[1-9][0-9]
-*.tfm
-
-#(r)(e)ledmac/(r)(e)ledpar
+#(e)ledmac/(e)ledpar
 *.end
-*.?end
 *.[1-9]
 *.[1-9][0-9]
 *.[1-9][0-9][0-9]
@@ -112,35 +74,11 @@ acs-*.bib
 *.gls
 *.glsdefs
 
-# gnuplottex
-*-gnuplottex-*
-
-# gregoriotex
-*.gaux
-*.gtex
-
-# htlatex
-*.4ct
-*.4tc
-*.idv
-*.lg
-*.trc
-*.xref
-
 # hyperref
 *.brf
 
-# knitr
-*-concordance.tex
-# TODO Comment the next line if you want to keep your tikz graphics files
-*.tikz
-*-tikzDictionary
-
 # listings
 *.lol
-
-# luatexja-ruby
-*.ltjruby
 
 # makeidx
 *.idx
@@ -150,115 +88,33 @@ acs-*.bib
 
 # minitoc
 *.maf
-*.mlf
-*.mlt
-*.mtc[0-9]*
-*.slf[0-9]*
-*.slt[0-9]*
-*.stc[0-9]*
+*.mtc
+*.mtc0
 
 # minted
-_minted*
 *.pyg
 
 # morewrites
 *.mw
 
 # nomencl
-*.nlg
 *.nlo
-*.nls
-
-# pax
-*.pax
-
-# pdfpcnotes
-*.pdfpc
 
 # sagetex
 *.sagetex.sage
 *.sagetex.py
 *.sagetex.scmd
 
-# scrwfile
-*.wrt
-
 # sympy
 *.sout
 *.sympy
 sympy-plots-for-*.tex/
 
-# pdfcomment
-*.upa
-*.upb
-
-# pythontex
-*.pytxcode
-pythontex-files-*/
-
-# tcolorbox
-*.listing
-
-# thmtools
-*.loe
-
-# TikZ & PGF
-*.dpth
-*.md5
-*.auxlock
-
 # todonotes
 *.tdo
-
-# vhistory
-*.hst
-*.ver
-
-# easy-todo
-*.lod
-
-# xcolor
-*.xcp
-
-# xmpincl
-*.xmpi
 
 # xindy
 *.xdy
 
-# xypic precompiled matrices
-*.xyc
-
-# endfloat
-*.ttt
-*.fff
-
-# Latexian
-TSWLatexianTemp*
-
-## Editors:
-# WinEdt
-*.bak
-*.sav
-
-# Texpad
-.texpadtmp
-
-# LyX
-*.lyx~
-
-# Kile
-*.backup
-
-# KBibTeX
-*~[0-9]*
-
-# auto folder when using emacs and auctex
-./auto/*
-*.el
-
-# expex forward references with \gathertags
-*-tags.tex
-
-# standalone packages
-*.sta
+# MAC files
+.DS_Store

--- a/packages/icmc.cls
+++ b/packages/icmc.cls
@@ -687,6 +687,17 @@
     \renewcommand{\demonstracaoname}{Demonstra{\c c}{\~a}o}
 }
 
+\addto\captionsenglish{% ingles
+	\renewcommand{\theoremaname}{Theorem}
+	\renewcommand{\proposicaoname}{Proposition}
+	\renewcommand{\lemaname}{Lemma}
+	\renewcommand{\corolarioname}{Corollary}
+	\renewcommand{\exemploname}{Example}
+	\renewcommand{\observacaoname}{Note}
+	\renewcommand{\definicaoname}{Definition}
+	\renewcommand{\demonstracaoname}{Demonstration}
+}
+
 \theoremstyle{definition}
 \newtheorem{teorema}{\theoremaname}
 \newtheorem{proposicao}{\proposicaoname}


### PR DESCRIPTION
Currently the labels for the theorems environments are only set for portuguese, so even if the settings say that the document is in English, the label will be like "Teorema", "Lema", "Corolario", and so on.